### PR TITLE
Remove custom DOWNLOADER_MIDDLEWARES to restore default proxy middleware

### DIFF
--- a/forums_scraper/settings.py
+++ b/forums_scraper/settings.py
@@ -34,18 +34,18 @@ RANDOMIZE_DOWNLOAD_DELAY = True
 COOKIES_ENABLED = True
 
 # Wyłącz niepotrzebne middleware dla szybszego scrapowania
-DOWNLOADER_MIDDLEWARES = {
-    'scrapy.downloadermiddlewares.robotstxt.RobotsTxtMiddleware': None,
-    'scrapy.downloadermiddlewares.httpauth.HttpAuthMiddleware': None,
-    'scrapy.downloadermiddlewares.defaultheaders.DefaultHeadersMiddleware': None,
-    'scrapy.downloadermiddlewares.redirect.MetaRefreshMiddleware': None,
-    'scrapy.downloadermiddlewares.retry.RetryMiddleware': None,
-    # Włączamy kompresję HTTP dla lepszej wydajności
-    'scrapy.downloadermiddlewares.httpcompression.HttpCompressionMiddleware': 810,
-    'scrapy.downloadermiddlewares.httpproxy.HttpProxyMiddleware': None,
-    # Custom retry middleware dla lepszego zarządzania timeoutami
-    'forums_scraper.middlewares.CustomRetryMiddleware': 550,
-}
+#DOWNLOADER_MIDDLEWARES = {
+#    'scrapy.downloadermiddlewares.robotstxt.RobotsTxtMiddleware': None,
+#    'scrapy.downloadermiddlewares.httpauth.HttpAuthMiddleware': None,
+#    'scrapy.downloadermiddlewares.defaultheaders.DefaultHeadersMiddleware': None,
+#    'scrapy.downloadermiddlewares.redirect.MetaRefreshMiddleware': None,
+#    'scrapy.downloadermiddlewares.retry.RetryMiddleware': None,
+#    # Włączamy kompresję HTTP dla lepszej wydajności
+#    'scrapy.downloadermiddlewares.httpcompression.HttpCompressionMiddleware': 810,
+#    'scrapy.downloadermiddlewares.httpproxy.HttpProxyMiddleware': None,
+#    # Custom retry middleware dla lepszego zarządzania timeoutami
+#    'forums_scraper.middlewares.CustomRetryMiddleware': 550,
+#}
 
 # Disable Telnet Console (enabled by default)
 #TELNETCONSOLE_ENABLED = False


### PR DESCRIPTION
## Summary
- comment out custom DOWNLOADER_MIDDLEWARES configuration so default middlewares including HttpProxyMiddleware are used

## Testing
- `pytest`
- `scrapy crawl wiara -s CLOSESPIDER_PAGECOUNT=1 -s ITEM_PIPELINES='{}' -s LOG_LEVEL=INFO -s LOG_FILE=/tmp/spider.log`


------
https://chatgpt.com/codex/tasks/task_e_68c6e0b848d483339ca23eb787275f33